### PR TITLE
Add a preface to the spells chapter

### DIFF
--- a/src/chapters/appendix/spells.tex
+++ b/src/chapters/appendix/spells.tex
@@ -2,10 +2,15 @@
 This chapter lists out a few example spells that could realistically be used in a game.
 Again, please note that this is not by any means an exhaustive list.
 
+Each spell listing describes the various facets of a spell. This includes the name,
+the spell's cost in Mana Points, a list of requirements in order to cast the spell,
+the range (either Close or a range in meters), and a description of the spell's
+effects.
+
 \subsection*{Breathe Foul Disease}
 \textbf{Cost} 2 MP\\
 \textbf{Requirements} Magic (Foul) specialisation. \\
-\textbf{Range} 7m. \\
+\textbf{Range} 7m \\
 \textbf{Description} Target takes $d6$ Fatigue damage. 
 Cannot be blocked or parried.
 
@@ -58,7 +63,7 @@ Lasts five minutes.
 \textbf{Cost} 2 MP\\
 \textbf{Requirements} Magic (Ice) specialisation. 
 Diamond as catalyst.\\
-\textbf{Range} 6m.\\
+\textbf{Range} 6m\\
 \textbf{Description} Deals $1d6+1$ damage.
 
 \subsection*{Soul Arrow}


### PR DESCRIPTION
This adds a description of the spell format to the spells chapter, and corrects a couple minor typos.

## Motivation

This clarifies the formatting of spells.

## Related Issue(s)

## Changes
- Add preface to spells chapter
- Remove trailing `.` character on some ranges
-

@ElectricCoffee
